### PR TITLE
Fixed link

### DIFF
--- a/types.md
+++ b/types.md
@@ -462,7 +462,7 @@ An unboxing conversion permits a *reference_type* to be explicitly converted to 
 *  From any *interface_type* to any *nullable_type* whose underlying type implements the *interface_type*.
 *  From the type `System.Enum` to any *enum_type*.
 *  From the type `System.Enum` to any *nullable_type* with an underlying *enum_type*.
-*  Note that an explicit conversion to a type parameter will be executed as an unboxing conversion if at run-time it ends up converting from a reference type to a value type ([Explicit dynamic conversions](conversions.md#explicit-dynamic-conversions)).
+*  Note that an explicit conversion to a type parameter will be executed as an unboxing conversion if at run-time it ends up converting from a reference type to a value type ([Explicit conversions involving type parameters](conversions.md#explicit-conversions-involving-type-parameters)).
 
 An unboxing operation to a *non_nullable_value_type* consists of first checking that the object instance is a boxed value of the given *non_nullable_value_type*, and then copying the value out of the instance.
 


### PR DESCRIPTION
This seems to be a mistake copied from the old spec. The C# 4.0 spec says:

> Note that an explicit conversion to a type parameter will be executed as an unboxing conversion if at run-time it ends up converting from a reference type to a value type (§6.2.6).

Where §6.2.6 is _Explicit dynamic conversions_ (_Explicit conversions involving type parameters_ is §6.2.7).
